### PR TITLE
Fix legacy android_usb detection to prevent false positives on modern devices

### DIFF
--- a/usb-tethering
+++ b/usb-tethering
@@ -30,7 +30,7 @@ write() {
     echo -n "$2" > "$1"
 }
 
-                                                                                   # This sets up the USB with whatever USB_FUNCTIONS are set to via configfs
+# This sets up the USB with whatever USB_FUNCTIONS are set to via configfs
 usb_setup_configfs() {
     [ -f /sys/class/udc/"$(ls /sys/class/udc | grep -v dummy | head -1)"/device/../mode ] && write /sys/class/udc/"$(ls /sys/class/udc | grep -v dummy | head -1)"/device/../mode peripheral
 
@@ -46,13 +46,18 @@ usb_setup_configfs() {
 
     if echo $USB_FUNCTIONS | grep -q "rndis"; then
         mkdir $GADGET_DIR/g1/functions/rndis.usb0
-        mkdir $GADGET_DIR/g1/functions/rndis_bam.rndis                                  fi
+        mkdir $GADGET_DIR/g1/functions/rndis_bam.rndis
+    fi
+
     echo $USB_FUNCTIONS | grep -q "mass_storage" && mkdir $GADGET_DIR/g1/functions/storage.0
 
-                                                                                mkdir $GADGET_DIR/g1/configs/c.1                                                    mkdir $GADGET_DIR/g1/configs/c.1/strings/0x409
+    mkdir $GADGET_DIR/g1/configs/c.1
+    mkdir $GADGET_DIR/g1/configs/c.1/strings/0x409
 
-                                      if [ "$IS_EXYNOS" == "true" ]; then
-       write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "Conf 1"               write $GADGET_DIR/g1/configs/c.1/MaxPower 0x3f    else
+    if [ "$IS_EXYNOS" == "true" ]; then
+       write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "Conf 1"
+       write $GADGET_DIR/g1/configs/c.1/MaxPower 0x3f
+    else
        write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "$USB_FUNCTIONS"
     fi
 
@@ -85,7 +90,7 @@ usb_setup_android_usb() {
     write $ANDROID_USB/enable          0
     write $ANDROID_USB/functions       ""
     write $ANDROID_USB/enable          1
-    sleep 0.5 # 0.5 delay to attempt to remove rndis function
+    usleep 500000 # 0.5 delay to attempt to remove rndis function
     write $ANDROID_USB/enable          0
     write $ANDROID_USB/idVendor        $USB_IDVENDOR
     write $ANDROID_USB/idProduct       $USB_IDPRODUCT

--- a/usb-tethering
+++ b/usb-tethering
@@ -30,7 +30,7 @@ write() {
     echo -n "$2" > "$1"
 }
 
-# This sets up the USB with whatever USB_FUNCTIONS are set to via configfs
+                                                                                   # This sets up the USB with whatever USB_FUNCTIONS are set to via configfs
 usb_setup_configfs() {
     [ -f /sys/class/udc/"$(ls /sys/class/udc | grep -v dummy | head -1)"/device/../mode ] && write /sys/class/udc/"$(ls /sys/class/udc | grep -v dummy | head -1)"/device/../mode peripheral
 
@@ -46,18 +46,13 @@ usb_setup_configfs() {
 
     if echo $USB_FUNCTIONS | grep -q "rndis"; then
         mkdir $GADGET_DIR/g1/functions/rndis.usb0
-        mkdir $GADGET_DIR/g1/functions/rndis_bam.rndis
-    fi
-
+        mkdir $GADGET_DIR/g1/functions/rndis_bam.rndis                                  fi
     echo $USB_FUNCTIONS | grep -q "mass_storage" && mkdir $GADGET_DIR/g1/functions/storage.0
 
-    mkdir $GADGET_DIR/g1/configs/c.1
-    mkdir $GADGET_DIR/g1/configs/c.1/strings/0x409
+                                                                                mkdir $GADGET_DIR/g1/configs/c.1                                                    mkdir $GADGET_DIR/g1/configs/c.1/strings/0x409
 
-    if [ "$IS_EXYNOS" == "true" ]; then
-       write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "Conf 1"
-       write $GADGET_DIR/g1/configs/c.1/MaxPower 0x3f
-    else
+                                      if [ "$IS_EXYNOS" == "true" ]; then
+       write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "Conf 1"               write $GADGET_DIR/g1/configs/c.1/MaxPower 0x3f    else
        write $GADGET_DIR/g1/configs/c.1/strings/0x409/configuration "$USB_FUNCTIONS"
     fi
 
@@ -90,7 +85,7 @@ usb_setup_android_usb() {
     write $ANDROID_USB/enable          0
     write $ANDROID_USB/functions       ""
     write $ANDROID_USB/enable          1
-    usleep 500000 # 0.5 delay to attempt to remove rndis function
+    sleep 0.5 # 0.5 delay to attempt to remove rndis function
     write $ANDROID_USB/enable          0
     write $ANDROID_USB/idVendor        $USB_IDVENDOR
     write $ANDROID_USB/idProduct       $USB_IDPRODUCT
@@ -105,10 +100,13 @@ usb_setup_android_usb() {
 usb_setup() {
     mount -t configfs none /sys/kernel/config || true
 
-    if [ -d $ANDROID_USB ]; then
-        usb_setup_android_usb $1
-    elif [ -d $GADGET_DIR ]; then
-        usb_setup_configfs $1
+    if [ -f /sys/class/android_usb/android0/enable ]; then
+        usb_setup_android_usb "$1"
+    elif [ -d "$GADGET_DIR" ]; then
+        usb_setup_configfs "$1"
+    else
+        echo "No supported USB gadget method found (android_usb or configfs)!"
+        return 1
     fi
 }
 


### PR DESCRIPTION
Currently, the usb_setup function checks for the existence of the /sys/class/android_usb/android0/ directory to use the legacy tethering method. However, on some modern devices, this directory exists as a vestigial component without the actual enable file, causing a false positive. This breaks the tethering setup because it attempts to write to a non-existent file instead of falling back to ConfigFS.

Changes:
Updated the condition to check for the existence of the enable file (-f /sys/class/android_usb/android0/enable) instead of just the directory. This ensures legacy devices still work while modern devices correctly fall back to usb_setup_configfs